### PR TITLE
Add basic dashboard layout

### DIFF
--- a/app/Controllers/Home.php
+++ b/app/Controllers/Home.php
@@ -23,8 +23,8 @@ class Home extends BaseController
             'ENVIRONMENT' => ENVIRONMENT,
         ];
 
-        // Render 'app/Views/welcome_message.blade.php'.
-        return $this->render('welcome_message', $data);
+        // Render 'app/Views/dashboard.blade.php'.
+        return $this->render('dashboard', $data);
     }
 
     /**

--- a/app/Views/dashboard.blade.php
+++ b/app/Views/dashboard.blade.php
@@ -1,0 +1,7 @@
+@extends('layout')
+
+@section('title','Panel de control')
+
+@section('content')
+<h1>Panel de control</h1>
+@endsection

--- a/app/Views/layout.blade.php
+++ b/app/Views/layout.blade.php
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>@yield('title','Dashboard')</title>
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            min-height: 100vh;
+            margin: 0;
+            display: flex;
+        }
+        .sidebar {
+            width: 200px;
+            flex-shrink: 0;
+            background-color: #f8f9fa;
+        }
+        .sidebar a {
+            display: block;
+            padding: 10px 15px;
+            color: #333;
+            text-decoration: none;
+        }
+        .sidebar a:hover {
+            background-color: #e9ecef;
+        }
+        .content {
+            flex-grow: 1;
+            padding: 20px;
+        }
+    </style>
+</head>
+<body>
+    <nav class="sidebar">
+        <a href="#">Inicio</a>
+        <a href="#">Dispositivos</a>
+        <a href="#">Configuración</a>
+    </nav>
+    <div class="content">
+        @yield('content')
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add new `layout.blade.php` with simple sidebar
- create `dashboard.blade.php` extending the layout
- load the dashboard view from `Home::index`

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_68498c19f8b8832e83b86497e47c37f0