### PR TITLE
Fix path handling for BladeOne rendering

### DIFF
--- a/app/Controllers/BaseController.php
+++ b/app/Controllers/BaseController.php
@@ -92,6 +92,12 @@ abstract class BaseController extends Controller
     public function render(string $filename, array $params = []): string
     {
         try {
+            // Allow the use of "folder/file" notation similar to CodeIgniter's
+            // view() helper by converting slashes to dot notation expected by
+            // BladeOne. This lets calls such as render('users/index') resolve
+            // correctly to "users.index".
+            $filename = str_replace(['\\', '/'], '.', trim($filename));
+
             // Render the template.
             return $this->templateEngine->run($filename, $params);
         } catch (\Throwable $e) {


### PR DESCRIPTION
## Summary
- ensure BaseController can render view paths using slashes

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6849bb086968832eabe9fd0006c4278a