### PR TITLE
Fix database port type

### DIFF
--- a/app/Config/Database.php
+++ b/app/Config/Database.php
@@ -185,7 +185,7 @@ class Database extends Config
             'compress'     => false,
             'strictOn'     => false,
             'failover'     => [],
-            'port'         => env('database.default.port', 3306),
+            'port'         => (int) env('database.default.port', 3306),
             'numberNative' => false,
             'foundRows'    => false,
             'dateFormat'   => [


### PR DESCRIPTION
## Summary
- cast DB port to integer in `Database.php` to satisfy mysqli driver

## Testing
- `php -l app/Config/Database.php`
- `./vendor/bin/phpunit --configuration phpunit.xml.dist` *(fails: SQLite3 extension missing)*

------
https://chatgpt.com/codex/tasks/task_e_6849bc977fb0832e83d2ede7d925f9ca