### PR TITLE
Add default admin user

### DIFF
--- a/netscopedb.sql
+++ b/netscopedb.sql
@@ -8,3 +8,7 @@ CREATE TABLE IF NOT EXISTS `users` (
   `created_at` DATETIME NULL,
   `updated_at` DATETIME NULL
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+-- Create default admin user
+INSERT INTO `users` (`nombre`, `contrasena`, `created_at`, `updated_at`)
+VALUES ('admin', '$2y$10$YkeQuYaAzQBeT78eigFaGuSkPH8lSVyzTWNDkD3jZgcLAUUvSd/qC', NOW(), NOW());


### PR DESCRIPTION
## Summary
- insert a default admin account into the SQL setup script

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6849c2a3b97c832e9918d3809356e05d