### PR TITLE
Add device monitoring status fields

### DIFF
--- a/app/Controllers/MikrotikDevices.php
+++ b/app/Controllers/MikrotikDevices.php
@@ -33,6 +33,8 @@ class MikrotikDevices extends BaseController
             'api_port'      => $this->request->getPost('api_port'),
             'username'      => $this->request->getPost('username'),
             'password'      => $this->request->getPost('password'),
+            'estado'        => 'Offline',
+            'ultima_actualizacion' => null,
             'notes'         => $this->request->getPost('notes'),
         ]);
         return redirect()->to('/mikrotik-devices');

--- a/app/Database/Migrations/2025-06-12-000000_CreateMikrotikDevices.php
+++ b/app/Database/Migrations/2025-06-12-000000_CreateMikrotikDevices.php
@@ -35,6 +35,15 @@ class CreateMikrotikDevices extends Migration
                 'type'       => 'VARCHAR',
                 'constraint' => 255,
             ],
+            'estado' => [
+                'type'       => 'VARCHAR',
+                'constraint' => 20,
+                'default'    => 'Offline',
+            ],
+            'ultima_actualizacion' => [
+                'type' => 'DATETIME',
+                'null' => true,
+            ],
             'notes' => [
                 'type' => 'TEXT',
                 'null' => true,

--- a/app/Models/MikrotikDeviceModel.php
+++ b/app/Models/MikrotikDeviceModel.php
@@ -15,6 +15,8 @@ class MikrotikDeviceModel extends Model
         'api_port',
         'username',
         'password',
+        'estado',
+        'ultima_actualizacion',
         'notes',
     ];
     protected $useTimestamps    = true;

--- a/app/Views/mikrotik_devices/dashboard.blade.php
+++ b/app/Views/mikrotik_devices/dashboard.blade.php
@@ -11,8 +11,12 @@
             <div class="card-body">
                 <h5 class="card-title">{{ $device['name'] }}</h5>
                 <p class="card-text">{{ $device['ddns_hostname'] }}</p>
-                <p class="card-text">Estado: Desconocido</p>
-                <p class="card-text">Última actualización: --</p>
+                <p class="card-text">Estado:
+                    <span class="badge {{ ($device['estado'] ?? 'Offline') === 'Online' ? 'bg-success' : 'bg-danger' }}">
+                        {{ $device['estado'] ?? 'Offline' }}
+                    </span>
+                </p>
+                <p class="card-text">Última actualización: {{ $device['ultima_actualizacion'] ?? '--' }}</p>
             </div>
         </div>
     </div>

--- a/monitor_ping.php
+++ b/monitor_ping.php
@@ -1,0 +1,30 @@
+<?php
+
+use App\Models\MikrotikDeviceModel;
+use CodeIgniter\Boot;
+
+require __DIR__ . '/app/Config/Paths.php';
+$paths = new Config\Paths();
+require $paths->systemDirectory . '/Boot.php';
+Boot::bootTest($paths);
+
+$model = new MikrotikDeviceModel();
+$devices = $model->findAll();
+
+$isWindows = stripos(PHP_OS, 'WIN') === 0;
+
+foreach ($devices as $device) {
+    $hostname = $device['ddns_hostname'];
+    $command  = ($isWindows ? 'ping -n 1 ' : 'ping -c 1 ') . escapeshellarg($hostname);
+    $output   = [];
+    $exitCode = 1;
+    exec($command, $output, $exitCode);
+
+    $estado = $exitCode === 0 ? 'Online' : 'Offline';
+
+    $model->update($device['id'], [
+        'estado'              => $estado,
+        'ultima_actualizacion' => date('Y-m-d H:i:s'),
+    ]);
+}
+

--- a/netscopedb.sql
+++ b/netscopedb.sql
@@ -21,6 +21,8 @@ CREATE TABLE IF NOT EXISTS `mikrotik_devices` (
   `api_port` INT(5) NOT NULL DEFAULT 8728,
   `username` VARCHAR(100) NOT NULL,
   `password` VARCHAR(255) NOT NULL,
+  `estado` VARCHAR(20) NOT NULL DEFAULT 'Offline',
+  `ultima_actualizacion` DATETIME NULL,
   `notes` TEXT NULL,
   `created_at` DATETIME NULL,
   `updated_at` DATETIME NULL


### PR DESCRIPTION
## Summary
- add `estado` and `ultima_actualizacion` fields to mikrotik devices
- allow the new fields in the model and default them on create
- create `monitor_ping.php` script to ping devices and update status
- display device state and last update in dashboard view
- update SQL schema and migration

## Testing
- `composer test` *(fails: No code coverage driver)*

------
https://chatgpt.com/codex/tasks/task_e_6849de6accb8832e80f2d9cf698b9602